### PR TITLE
Exclude external deps when getting packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const findPackages = (packageSpecs, rootDirectory) => {
       []
     )
     .map(location => ({ location, package: loadPackage(location) }))
+    .filter(({ location }) => !location.includes('node_modules'))
     .filter(({ package: { name } = {} }) => name);
 };
 


### PR DESCRIPTION
When using yarn workspaces, it is possible that due to version mismatches, a workspaces has its own `node_modules` folder next to its `package.json` with mismatching dependencies. While yarn accounts for those when evaluating the globs in the `workspaces` key, this package currently does not.

The proposed change simply excludes all matches that have `node_modules' in their path, which should fix the issue.